### PR TITLE
Add new Earthfile keywords

### DIFF
--- a/syntax/Earthfile.vim
+++ b/syntax/Earthfile.vim
@@ -47,7 +47,7 @@ syn match earthfileTargetReference '\(\w\|_\|\-\|/\|:\|+\|\.\)*\s' contained nex
 syn keyword earthlyConditional IF ELSE END
 hi def link earthlyConditional Conditional
 
-syn match earthfileKeyword '^\s*LOCALLY\s*\|^\s*FROM DOCKERFILE\s*\|^\s*COPY\s*\|^\s*SAVE ARTIFACT\s*\|^\s*SAVE IMAGE\s*\|^\s*RUN\s*\|^\s*LABEL\s*\|^\s*EXPOSE\s*\|^\s*VOLUME\s*\|^\s*USER\s*\|^\s*ENV\s*\|^\s*ARG\s*\|^\s*BUILD\s*\|^\s*WORKDIR\s*\|^\s*ENTRYPOINT\s*\|^\s*CMD\s*\|^\s*GIT CLONE\s*\|^\s*VERSION\s*\|^\s*DOCKER LOAD\s*\|^\s*DOCKER PULL\s*\|^\s*HEALTHCHECK\s*NONE\|^\s*HEALTHCHECK\s*CMD\|^\s*WITH DOCKER\s*\|^\s*CACHE'
+syn match earthfileKeyword '^\s*ADD\s*\|^\s*ARG\s*\|^\s*BUILD\s*\|^\s*CACHE\s*\|^\s*CMD\s*\|^\s*COMMAND\s*\|^\s*COPY\s*\|^\s*DO\s*\|^\s*DOCKER LOAD\s*\|^\s*DOCKER PULL\s*\|^\s*ENTRYPOINT\s*\|^\s*ENV\s*\|^\s*EXPOSE\s*\|^\s*FROM DOCKERFILE\s*\|^\s*GIT CLONE\s*\|^\s*HEALTHCHECK\s*CMD\|^\s*HEALTHCHECK\s*NONE\|^\s*HOST\s*\|^\s*IMPORT\s*\|^\s*LABEL\s*\|^\s*LOCALLY\s*\|^\s*ONBUILD\s*\|^\s*PIPELINE\s*\|^\s*PROJECT\s*\|^\s*RUN\s*\|^\s*SAVE ARTIFACT\s*\|^\s*SAVE IMAGE\s*\|^\s*SHELL\s*\|^\s*STOPSIGNAL\s*\|^\s*TRIGGER\s*\|^\s*USER\s*\|^\s*VERSION\s*\|^\s*VOLUME\s*\|^\s*WITH DOCKER\s*\|^\s*WORKDIR'
 syn match earthfileKeyword '^\s*FROM\s*' nextgroup=earthfileBaseImage
 syn match earthfileBaseImage '\S\+' contained
 


### PR DESCRIPTION
### Changes

- Added keywords (from https://github.com/earthly/earthly/blame/main/ast/parser/EarthParser.g4): 
ARG, BUILD, COMMAND, DO, HOST, IMPORT, ONBUILD, PIPELINE, PROJECT, SHELL, STOPSIGNAL, TRIGGER
- Sorted the regex string alphabetically

### Context

Hi, I was trying out newly supported Earthly keywords and saw in Neovim the new keywords didn't highlight so wanted to update this plugin.

Apologies, I did only add keywords directly, I didn't check if the other syntax that's handled on lines 11-48 had changed. I should be able to take a closer look at this if that also needs updating.

Thanks!


#### (very minimal) Testing

Just using the simple example from https://earthly.dev/, happy to test this out on other Earthfiles I find.

```
g diff nvim/init.vim
diff --git a/nvim/init.vim b/nvim/init.vim
index 0416afa..f6508ec 100644
--- a/nvim/init.vim
+++ b/nvim/init.vim
-Plug 'earthly/earthly.vim', { 'branch': 'main' }
+Plug 'camerondurham/earthly.vim', { 'branch': 'cam/new-earthfile-keywords' }
```

*Before*
<img width="240" alt="Earthly-Before" src="https://user-images.githubusercontent.com/17013462/224599136-d3beeef2-0631-4e50-bfb6-9880ff7ba131.png">



*After*
<img width="280" alt="Earthly-After" src="https://user-images.githubusercontent.com/17013462/224599154-1267ee72-8e10-400b-83dd-582a78e0424e.png">
