### PR TITLE
Target *.earth files for syntax highlighting

### DIFF
--- a/ftdetect/earthfiletype.vim
+++ b/ftdetect/earthfiletype.vim
@@ -1,3 +1,3 @@
 au BufRead,BufNewFile Earthfile set filetype=Earthfile
-au BufRead,BufNewFile build.earth set filetype=Earthfile
+au BufRead,BufNewFile *.earth set filetype=Earthfile
 


### PR DESCRIPTION
For composability, it would be helpful to have multiple Earthfile names targeted for syntax highlighting. 